### PR TITLE
added el=[type] to info url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ function download(options, stream, info) {
       format = formats.filter(function(format) {
         return format.itag === options.quality;
       })[0];
+      break;
 
   }
 
@@ -146,14 +147,15 @@ ytdl.getInfo = function getInfo(link, requestOptions, callback) {
   }
 
   var elTypes = ['&el=embedded', '&el=detailpage', '&el=vevo', ''], 
-      el,
       info;
 
-  var getInfoForEl = (function getInfoForEl(link, el, requestOptions, callback) {
-    el = elTypes.shift();
-
-    if (el !== undefined) {
+  function getInfoForEl(el) {
+    if (el === undefined) {
+      onError(info);
+    }
+    else {
       requestOptions.url = INFO_URL + id + el;
+
       request(requestOptions, function(err, res, body) {
         if (err) return callback(err);
         if (res.statusCode !== 200) {
@@ -162,25 +164,25 @@ ytdl.getInfo = function getInfo(link, requestOptions, callback) {
         info = qs.parse(body);
 
         if (info.status === 'ok') {
-            onSuccess(info, callback);
+            console.log(requestOptions.url, el);
+            onSuccess(info);
         }
         else {
-          getInfoForEl(link, el, requestOptions, callback);
+          getInfoForEl(elTypes.shift());
         }
       });
     }
-    else {
-      onError(info);
-    }
-  })(link, el, requestOptions, callback);
+  };
 
-  var onError = function onError(info, callback) {
+  getInfoForEl(elTypes.shift());
+
+  var onError = function onError(info) {
     var err = new Error('Error ' + info.errorcode + ': ' + info.reason);
     err.info = info;
     callback(err);
   };
 
-  var onSuccess = function onSuccess(info, callback) { 
+  var onSuccess = function onSuccess(info) { 
 
     // split some keys by commas
     KEYS_TO_SPLIT.forEach(function(key) {


### PR DESCRIPTION
Not sure if you still maintain node-ytdl, but I modified ytdl.getInfo() to try el=embedded, detailpage, vevo, and blank in the info url. An error is raised if none of them work. I found similar logic in https://github.com/rg3/youtube-dl/ and it seems to fix a problem with certain types of videos not downloading. 

Thanks.
