### PR TITLE
fix command line options checking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ function download(options, stream, info) {
 
     default:
       format = formats.filter(function(format) {
-        return format.itag === options.quality;
+        return +format.itag === options.quality;
       })[0];
 
   }


### PR DESCRIPTION
when doing `ytdl -q 18` it uses `===` to compare a number to a string so it is always false. this 1 character pull req makes it compare a number to a number so it will work as expected
