### PR TITLE
Handle empty 'fmt_list' or 'url_encoded_fmt_stream_map' on live streams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,31 +192,38 @@ ytdl.getInfo = function getInfo(link, requestOptions, callback) {
       }
     });
 
-    info.fmt_list = info.fmt_list.map(function(format) {
-      return format.split('/');
-    });
+    if (info.fmt_list) {
+      info.fmt_list = info.fmt_list.map(function(format) {
+        return format.split('/');
+      });
+    } else {
+      info.fmt_list = [];
+    }
 
-    info.formats = info.url_encoded_fmt_stream_map
-      .split(',')
-      .map(function(format) {
-        var data = qs.parse(format);
-        if (data.sig) {
-          data.url += '&signature=' + data.sig;
-        }
-        format = FORMATS[data.itag];
+    if (info.url_encoded_fmt_stream_map) {
+      info.formats = info.url_encoded_fmt_stream_map
+        .split(',')
+        .map(function(format) {
+          var data = qs.parse(format);
+          if (data.sig) {
+            data.url += '&signature=' + data.sig;
+          }
+          format = FORMATS[data.itag];
 
-        if (!format) {
-          err = new Error('No such format for itag ' + data.itag + ' found');
-          return;
-        }
+          if (!format) {
+            err = new Error('No such format for itag ' + data.itag + ' found');
+            return;
+          }
 
-        Hash(format).forEach(function(val, key) {
-          data[key] = val;
+          Hash(format).forEach(function(val, key) {
+            data[key] = val;
+          });
+
+          return data;
         });
-
-        return data;
-      })
-      ;
+    } else {
+      info.formats = [];
+    }
 
     delete info.url_encoded_fmt_stream_map;
 


### PR DESCRIPTION
Hi,
It looks like this breaks when calling getInfo on a YouTube live stream. 

The info object returned has fmt_list and url_encoded_fmt_stream_map as empty strings, which throws an error when map is called. 

I've wrapped these calls in a conditional:

```
    if (info.fmt_list) {
      info.fmt_list = info.fmt_list.map(function(format) {
        return format.split('/');
      });
    } else {
      info.fmt_list = [];
    }
```

Info object: https://gist.github.com/liuhenry/5528941
