### PR TITLE
ytdl: simplified getting package information

### DIFF
--- a/bin/ytdl.js
+++ b/bin/ytdl.js
@@ -7,8 +7,7 @@ var cliff = require('cliff');
 require('colors');
 
 
-var info = JSON.parse(
-    fs.readFileSync(path.resolve(__dirname, '..', 'package.json')));
+var info = require('../package');
 
 var opts = require('nomnom')
   .option('version', {


### PR DESCRIPTION
Simplified getting package information in `bin/ytdl.js`.
