### PR TITLE
added filename sanitizing

### DIFF
--- a/bin/ytdl.js
+++ b/bin/ytdl.js
@@ -298,7 +298,7 @@ if (opts.infoJson) {
         output += '.' + format.container;
       }
 
-      // Parses & sanitises output filename for any illegal charcters
+      // Parses & sanitises output filename for any illegal characters
       var parsedOutput = path.posix.parse(output);
       output = path.format({
         dir: parsedOutput.dir,

--- a/bin/ytdl.js
+++ b/bin/ytdl.js
@@ -299,7 +299,7 @@ if (opts.infoJson) {
       }
 
       // Parses & sanitises output filename for any illegal characters
-      var parsedOutput = path.posix.parse(output);
+      var parsedOutput = path.parse(output);
       output = path.format({
         dir: parsedOutput.dir,
         base: sanitizeName(parsedOutput.base)

--- a/bin/ytdl.js
+++ b/bin/ytdl.js
@@ -102,11 +102,12 @@ const opts = require('nomnom')
   ;
 
 
-const path    = require('path');
-const fs      = require('fs');
-const ytdl    = require('ytdl-core');
-const homedir = require('homedir');
-const util    = require('../lib/util');
+const path         = require('path');
+const fs           = require('fs');
+const ytdl         = require('ytdl-core');
+const homedir      = require('homedir');
+const util         = require('../lib/util');
+const sanitizeName = require('sanitize-filename');
 
 const chalk = require('chalk');
 const label = chalk.bold.gray;
@@ -296,6 +297,14 @@ if (opts.infoJson) {
       if (!ext && format.container) {
         output += '.' + format.container;
       }
+
+      // Parses & sanitises output filename for any illegal charcters
+      var parsedOutput = path.posix.parse(output);
+      output = path.format({
+        dir: parsedOutput.dir,
+        base: sanitizeName(parsedOutput.base)
+      });
+
       readStream.pipe(fs.createWriteStream(output))
         .on('error', (err) => {
           console.error(err.message);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash.throttle": "^4.1.1",
     "nomnom": "~1.8.0",
     "progress-bar": "~0.1.1",
+    "sanitize-filename": "^1.6.1",
     "ytdl-core": ">=0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #68.
Simple parsing and sanitizing.

No check for if the sanitized name is empty (""). The entire filename would have to be illegal, you may want to throw an error at that point.

Deconstructs output path with `path.postix` so it [works cross-platform](https://nodejs.org/api/path.html#path_windows_vs_posix).

Sanitizes name with [`sanitize-filename`](https://www.npmjs.com/package/sanitize-filename)